### PR TITLE
prepare for 1.14.0 release

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache OpenWhisk Runtime Python
-Copyright 2016-2019 The Apache Software Foundation
+Copyright 2016-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/core/pythonAction/CHANGELOG.md
+++ b/core/pythonAction/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 # Python 3 OpenWhisk Runtime Container
 
+## 1.14.0
+  - Update base image to openwhisk/dockerskeleton:1.14.0
+  - Support for __OW_ACTION_VERSION (openwhisk/4761)
+
 ## 1.0.3
 Changes:
   - Update base image to openwhisk/dockerskeleton:1.3.3

--- a/core/pythonAction/Dockerfile
+++ b/core/pythonAction/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # Dockerfile for python actions, overrides and extends ActionRunner from actionProxy
-FROM openwhisk/dockerskeleton:nightly
+FROM openwhisk/dockerskeleton:1.14.0
 
 RUN apk add --no-cache \
         bzip2-dev \


### PR DESCRIPTION
1. use dockerskeleton:1.14.0 as base image for pythonaction
2. update NOTICE and CHANGELOG