### PR TITLE
Ambiguous project name changed to python3ActionLoop

### DIFF
--- a/tools/travis/publish.sh
+++ b/tools/travis/publish.sh
@@ -35,7 +35,7 @@ if [ ${RUNTIME_VERSION} == "3" ]; then
 elif [ ${RUNTIME_VERSION} == "3-ai" ]; then
   RUNTIME="python3AiAction"
 elif [ ${RUNTIME_VERSION} == "3-loop" ]; then
-  RUNTIME="pythonActionLoop"
+  RUNTIME="python3ActionLoop"
 elif [ ${RUNTIME_VERSION} == "3-loopai" ]; then
   RUNTIME="python3AiActionLoop"
 fi


### PR DESCRIPTION
Opening this PR to get the discussion rolling. Master builds of have been completing with a status of errored due to:

> * What went wrong:
Project 'pythonActionLoop' is ambiguous in project ':core'. Candidates are: 'python2ActionLoop', 'python3ActionLoop'.

The error stems from the ${RUNTIME} argument in the gradle command in the publish.sh script being ambiguous.
https://github.com/apache/openwhisk-runtime-python/blob/master/tools/travis/publish.sh#L49
https://github.com/apache/openwhisk-runtime-python/blob/master/tools/travis/publish.sh#L58

I assume this should be python3ActionLoop and not 2 given Python 2's end of life and also the runtime version looking for 3-x in the rest of the arguments.