### PR TITLE
Update to golang:1.15 and debian buster (security).

### DIFF
--- a/core/python2ActionLoop/Dockerfile
+++ b/core/python2ActionLoop/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # build go proxy from source
-FROM golang:1.12 AS builder_source
+FROM golang:1.15 AS builder_source
 ARG GO_PROXY_GITHUB_USER=apache
 ARG GO_PROXY_GITHUB_BRANCH=master
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
@@ -25,7 +25,7 @@ RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
    mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.12 AS builder_release
+FROM golang:1.15 AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.12@1.15.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\

--- a/core/python3ActionLoop/Dockerfile
+++ b/core/python3ActionLoop/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # build go proxy from source
-FROM golang:1.12 AS builder_source
+FROM golang:1.15 AS builder_source
 ARG GO_PROXY_GITHUB_USER=apache
 ARG GO_PROXY_GITHUB_BRANCH=master
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
@@ -24,7 +24,7 @@ RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
    mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.12 AS builder_release
+FROM golang:1.15 AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.12@1.15.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
@@ -32,7 +32,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM python:3.7-stretch
+FROM python:3.7-buster
 ARG GO_PROXY_BUILD_FROM=source
 
 # Install common modules for python

--- a/core/python3AiActionLoop/Dockerfile
+++ b/core/python3AiActionLoop/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # build go proxy from source
-FROM golang:1.12 AS builder_source
+FROM golang:1.15 AS builder_source
 ARG GO_PROXY_GITHUB_USER=apache
 ARG GO_PROXY_GITHUB_BRANCH=master
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
@@ -25,7 +25,7 @@ RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
    mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.12 AS builder_release
+FROM golang:1.15 AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.12@1.15.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/${GO_PROXY_RELEASE_VERSION}.tar.gz\

--- a/tests/src/test/scala/runtime/actionContainers/PythonActionLoopExtraTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonActionLoopExtraTests.scala
@@ -64,7 +64,7 @@ trait PythonActionLoopExtraTests {
     checkStreams(out, err, {
       case (o, e) =>
         o shouldBe empty
-        e should include("command exited before ack")
+        e should include("Command exited abruptly during initialization.")
     })
   }
 


### PR DESCRIPTION
- Update to golang:1.15 to continue to get security fixes.
- Update from debian stretch to debian buster to stay at latest stable to continue getting security fixes.
- Adjust testcase in PythonActionLoopExtraTests.scala to match changed message wording in the go runtime (https://github.com/apache/openwhisk-runtime-go/pull/131).