### PR TITLE
fix failing greenlet building

### DIFF
--- a/core/python2ActionLoop/Dockerfile
+++ b/core/python2ActionLoop/Dockerfile
@@ -40,6 +40,7 @@ ARG GO_PROXY_BUILD_FROM=release
 # Upgrade and install basic Python dependencies
 RUN apk add --no-cache \
         bash \
+        build-base \
         bzip2-dev \
         gcc \
         libc-dev \


### PR DESCRIPTION
- should resolve issue #94
- command `./gradlew core:python2ActionLoop:distDocker` builds successful  