### PR TITLE
Resolve akka versions explicitly.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -28,6 +28,7 @@ gradle.ext.openwhisk = [
 
 gradle.ext.scala = [
     version: '2.12.7',
+    depVersion: '2.12',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
 
@@ -35,3 +36,6 @@ gradle.ext.scalafmt = [
     version: '1.5.0',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
+
+gradle.ext.akka = [version: '2.6.12']
+gradle.ext.akka_http = [version: '10.2.4']

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:tests"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:test-sources"
+    implementation group: 'com.typesafe.akka', name: "akka-http2-support_${gradle.scala.depVersion}", version: "${gradle.akka_http.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-http-xml_${gradle.scala.depVersion}", version: "${gradle.akka_http.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-discovery_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-protobuf_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-remote_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-cluster_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
- An akka upgrade in apache/openwhisk required changes here to successfully build and run the test cases.
- fix fix taken from [openwhisk-runtime-docker 89](apache/openwhisk-runtime-docker#89)