### PR TITLE
Update Travis Distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: xenial
+dist: focal 
 jdk: openjdk8
 language:
   - python


### PR DESCRIPTION
Updating Travis distribution to current Ubuntu LTS version 20.04 (Focal)