### PR TITLE
Fix setup.py install is deprecated in python3.10

### DIFF
--- a/core/python310Action/requirements.txt
+++ b/core/python310Action/requirements.txt
@@ -1,2 +1,5 @@
 # default packages available for action-python-v3.10
 -r requirements_common.txt
+
+# fix issue: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools
+setuptools == 58.2.0


### PR DESCRIPTION
- [x] Fix setup.py install is deprecated in python3.10

I tested current master's python3.10 iamge in my local,  when invoked action with python3.10 image, the `/init` step failed, the action container's logs as below
```shell
[root@nccddev130026 32d8fd9bd1fa4319bba6b5436cfc885453adfcc3d20a70484638bc4a50028281]# docker logs 041bcd5d0e9b
/usr/local/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(

XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
```

Activation logs as below
```
    "logs": [
        "2022-08-09T03:20:33.047906766Z stderr: /usr/local/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.",
        "2022-08-09T03:20:33.047948564Z stderr:   warnings.warn(",
        "2022-08-09T03:20:33.047963151Z stderr: ",
        "2022-08-09T03:20:33.050624Z    stderr: The action did not initialize or run as expected. Log data might be missing."
    ],
```

This pr fixed it.(after applied this pr in my local, can invoke python3.10 action successfully)