### PR TITLE
Update travis build vm dist form xenial to focal This bings the machi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ services:
   - docker
 # required to support multi-stage build
 addons:
-   apt:
-     packages:
-       - docker-ce
+  apt:
+    packages:
+     - docker-ce
 
 before_install:
   - "./tools/travis/setup.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@
 #
 
 sudo: required
-dist: xenial
-jdk: openjdk8
+dist: focal
+jdk: openjdk11
 language:
   - python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ services:
 # required to support multi-stage build
 addons:
   apt:
+    sources:
+     - sourcelist: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
     packages:
      - docker-ce
 


### PR DESCRIPTION
…nes to the build VM to a more up to date Ubuntu version which should also reduce the risk of loosing support for the version and use openjdk11