### PR TITLE
Script to build docker images locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,17 @@ def main(args):
 
 To learn more about using Python actions to build serverless applications, check out the main project documentation [here](https://github.com/apache/openwhisk/blob/master/docs/actions-python.md).
 
-## Build Runtimes
+## Build Python Runtime
 
 There are two options to build the Python runtime:
 
-- Building locally: [tutorial](tutorials/local_build.md)
-- Using OpenWhisk Actions.
+- Build using Docker
+- Build using Gradle
 
-### Building Python Runtime using OpenWhisk Actions
+### Build Python Runtime using Docker
+The runtimes can be built using Docker locally. Please follow the detailed [tutorial](tutorials/local_build.md) to build and test the runtime locally.
+
+### Building Python Runtime using Gradle
 
 Pre-requisites
 

--- a/tutorials/local_build.md
+++ b/tutorials/local_build.md
@@ -125,7 +125,7 @@ This step can be run using either [curl](https://curl.se/), [wget](https://www.g
 - Using wget
 
   The option `--post-file` signifies we're issuing a POST request in wget
-      
+
       wget --post-file=python-data-init-run.json --header="Content-Type: application/json" http://localhost/init
 
 - Using postman
@@ -141,31 +141,31 @@ Server will remain silent in this case
 
 #### Run function
 Now we can invoke/run our function agains the `run` API with:
-- Using curl 
+- Using curl
    - `POST` request
-        
+
          curl -d "@python-data-init-run.json" -H "Content-Type: application/json" http://localhost/run
-   
+
    - `GET` request
-         
+
          curl --data-binary "@python-data-init-run.json" -H "Content-Type: application/json" http://localhost/run
-      
+   
 - Using wget
    - `POST` request
-   
+
       The `-O-` is to redirect `wget` response to `stdout`.
-   
+
          wget -O- --post-file=python-data-init-run.json --header="Content-Type: application/json" http://localhost/run
 
-   - `GET` request   
-   
+   - `GET` request
+
          wget -O- --body-file=python-data-init-run.json --method=GET --header="Content-Type: application/json" http://localhost/run
 
 - Using postman
-   
+
    The above can also be achieved with [Postman](https://www.postman.com/) by setting the headers and body accordingly.
 
-#### (Recommended) Run function 
+#### (Recommended) Run function
 The same file `python-data-init-run.json` from function initialization request is used to trigger(run) the function. It is not necessary nor recommended. To trigger a function we only need to pass the parameters of the function. Hence, instead in the above example, it is prefered to create a file called `python-data-params.json` that looks like the following:
 
 ```json
@@ -224,7 +224,7 @@ Issue a `POST` request against the `init` API with the following command:
 - Using curl
 
    curl -d "@python-data-init-params.json" -H "Content-Type: application/json" http://localhost/init
-   
+
 - Using wget
 
    wget --post-file=python-data-init-params.json --header="Content-Type: application/json" http://localhost/init
@@ -244,28 +244,28 @@ Server will remain silent in this case
 #### Run function
 To run/trigger the function issue requests against the `run` API with the following command:
 
-- Using curl 
+- Using curl
    - `POST` request
-        
+
          curl -d "@python-data-run-params.json" -H "Content-Type: application/json" http://localhost/run
-   
+
    - `GET` request
-         
+
          curl --data-binary "@python-data-run-params.json" -H "Content-Type: application/json" http://localhost/run
-      
+
 - Using wget
    - `POST` request
-   
+
       The `-O-` is to redirect `wget` response to `stdout`.
-   
+
          wget -O- --post-file=python-data-run-params.json --header="Content-Type: application/json" http://localhost/run
 
-   - `GET` request   
-   
+   - `GET` request
+
          wget -O- --body-file=python-data-run-params.json --method=GET --header="Content-Type: application/json" http://localhost/run
 
 - Using postman
-   
+
    The above can also be achieved with [Postman](https://www.postman.com/) by setting the headers and body accordingly.
 
 #### Expected response of Run function step
@@ -331,7 +331,7 @@ Initialize our fibonacci function by issuing a `POST` request against the `init`
 - Using wget
 
    wget --post-file=python-fib-init.json --header="Content-Type: application/json" http://localhost/init
-   
+
 - Using postman
 
   The above can also be achieved with [Postman](https://www.postman.com/) by setting the headers and body accordingly
@@ -346,28 +346,28 @@ You've noticed by now that `init` API always returns `{"ok":true}` for a success
 #### Run function
 Trigger/run the function with a request against the `run` API with the following command:
 
-- Using curl 
+- Using curl
    - `POST` request
-        
+
          curl -d "@python-fib-run.json" -H "Content-Type: application/json" http://localhost/run
-   
+
    - `GET` request
-         
+
          curl --data-binary "@python-fib-run.json" -H "Content-Type: application/json" http://localhost/run
-      
+
 - Using wget
    - `POST` request
-   
+
       The `-O-` is to redirect `wget` response to `stdout`.
-   
+
          wget -O- --post-file=python-fib-run.json --header="Content-Type: application/json" http://localhost/run
 
-   - `GET` request   
-   
+   - `GET` request
+
          wget -O- --body-file=python-fib-run.json --method=GET --header="Content-Type: application/json" http://localhost/run
 
 - Using postman
-   
+
    The above can also be achieved with [Postman](https://www.postman.com/) by setting the headers and body accordingly.
 
 #### Expected response of Run function step

--- a/tutorials/local_build.md
+++ b/tutorials/local_build.md
@@ -149,7 +149,7 @@ Now we can invoke/run our function agains the `run` API with:
    - `GET` request
 
          curl --data-binary "@python-data-init-run.json" -H "Content-Type: application/json" http://localhost/run
-   
+
 - Using wget
    - `POST` request
 

--- a/tutorials/local_build.md
+++ b/tutorials/local_build.md
@@ -33,9 +33,12 @@ cd openwhisk-runtime-python
 2. Build docker
 
 Build using Python 3.7 (recommended). This tutorial assumes you're building with python 3.7.
-
+Run local_build.sh with the correct parameters to build docker
 ```
-docker build -t action-python-v3.7:1.0-SNAPSHOT $(pwd)/core/python3Action
+cd /tutorials
+chmod 755 local_build.sh
+cd ..
+./tutorials/local_build.sh -r python3Action -t action-python-v3.7:1.0-SNAPSHOT
 ```
 
 2.1. Check docker `IMAGE ID` (3rd column) for repository `action-python-v3.7`

--- a/tutorials/local_build.sh
+++ b/tutorials/local_build.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 helperInstructions()
 {
    echo ""

--- a/tutorials/local_build.sh
+++ b/tutorials/local_build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+helperInstructions()
+{
+   echo ""
+   echo "Usage: $0 -r runtimeParameter -t dockerImageTag"
+   echo -e "\t-r Specific runtime image folder name to be built, it can be one of python3Action, python36AiAction, python39Action or python310Action"
+   echo -e "\t-t The name for docker image and tag used for building the docker image. Example: action-python-v3.7:1.0-SNAPSHOT"
+   exit 1 #Exit script
+}
+
+while getopts "r:t:" opt
+do
+   case "$opt" in
+      r) runtimeParameter="$OPTARG" ;;
+      t) dockerImageTag="$OPTARG" ;;
+      [?]) helperInstructions ;; # Print helperInstructions in case parameter is not found
+   esac
+done
+
+# Print helperInstructions in case parameters are empty
+if [ -z "$runtimeParameter" ] || [ -z "$dockerImageTag" ] || ( [[ "$runtimeParameter" != "python3Action" ]] && [[ "$runtimeParameter" != "python36AiAction" ]] && [[ "$runtimeParameter" != "python39Action" ]] && [[ "$runtimeParameter" != "python310Action" ]] )
+ then
+   echo "Runtime parameter is empty or not supported";
+   helperInstructions
+fi
+
+# For every runtime 1. copy the required dependent folders 2. build the docker image 3. delete the copied folder
+if [[ "$runtimeParameter" == "python3Action" ]]
+ then
+    echo "Building docker for python3Action."
+    cp $(pwd)/core/requirements_common.txt $(pwd)/core/python3Action/requirements_common.txt
+    docker build -t "$dockerImageTag" $(pwd)/core/python3Action
+    rm $(pwd)/core/python3Action/requirements_common.txt
+elif [[ "$runtimeParameter" == "python36AiAction" ]]
+  then
+    echo "Building docker for python36AiAction."
+    cp $(pwd)/core/requirements_common.txt $(pwd)/core/python36AiAction/requirements_common.txt
+    cp -r $(pwd)/core/python3Action/bin $(pwd)/core/python36AiAction/bin
+    cp -r $(pwd)/core/python3Action/lib $(pwd)/core/python36AiAction/lib
+    docker build -t "$dockerImageTag" $(pwd)/core/python36AiAction
+    rm $(pwd)/core/python36AiAction/requirements_common.txt
+    rm -r $(pwd)/core/python36AiAction/bin
+    rm -r $(pwd)/core/python36AiAction/lib
+elif [[ "$runtimeParameter" == "python39Action" ]]
+  then
+    echo "Building docker for python39Action."
+    cp $(pwd)/core/requirements_common.txt $(pwd)/core/python39Action/requirements_common.txt
+    cp -r $(pwd)/core/python3Action/bin $(pwd)/core/python39Action/bin
+    cp -r $(pwd)/core/python3Action/lib $(pwd)/core/python39Action/lib
+    docker build -t "$dockerImageTag" $(pwd)/core/python39Action
+    rm $(pwd)/core/python39Action/requirements_common.txt
+    rm -r $(pwd)/core/python39Action/bin
+    rm -r $(pwd)/core/python39Action/lib
+elif [[ "$runtimeParameter" == "python310Action" ]]
+  then
+    echo "Building docker for python310Action."
+    cp $(pwd)/core/requirements_common.txt $(pwd)/core/python310Action/requirements_common.txt
+    cp -r $(pwd)/core/python3Action/bin $(pwd)/core/python310Action/bin
+    cp -r $(pwd)/core/python3Action/lib $(pwd)/core/python310Action/lib
+    docker build -t "$dockerImageTag" $(pwd)/core/python310Action
+    rm $(pwd)/core/python310Action/requirements_common.txt
+    rm -r $(pwd)/core/python310Action/bin
+    rm -r $(pwd)/core/python310Action/lib
+fi


### PR DESCRIPTION
I was following the instructions to build the docker file locally by following the tutorial on [here](https://github.com/apache/openwhisk-runtime-python/blob/master/tutorials/local_build.md).
However the command for `docker build` was failing. I noticed failures in building the docker files for all available runtimes. The reason being the expected dependent files/folders were not available in the docker context. The Gradle builds would essentially pass as they are copying the dependencies before building the docker. For example https://github.com/apache/openwhisk-runtime-python/blob/master/core/python3Action/build.gradle#L25

To solve this problem, I had brainstormed multiple solutions, I came up with this one as it does not affect any dependencies on the dockerfile. The gradle builds should be able to pass as they were earlier.

Solution:
- Create a script that would take in two arguments 
   1. Runtime folder name - The runtime that needs to be built
   2. Docker Image tag - Name of the docker image
- Example command `./tutorials/local_build.sh -r python3Action -t action-python-v3.7:1.0-SNAPSHOT`

The script tries to mimic the Gradle files by copying the dependent folder/files, building the docker file and then deleting the dependent folders/files. I have updated the tutorial document with the same instructions. This PR would help anyone trying to build the runtime images locally.

