### PR TITLE
Update python:3.11 and python:3.10 to debian bookworm.

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -18,6 +18,10 @@
 -->
 
 # Python 3 OpenWhisk Runtime Container
+
+## Next version
+  - Update the python:3.11 and the python:3.10 action runtimes to bookworm as buster is in the final support phase and therefore the vulnerability updates for buster are more and more delayed. (#146)
+
 ## 1.18.0
   - Add Python 3.10 runtime. (#128)
   - Add Python 3.11 Runtime (#140)

--- a/core/python310Action/Dockerfile
+++ b/core/python310Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy
 
-FROM python:3.10-buster
+FROM python:3.10-bookworm
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/python311Action/Dockerfile
+++ b/core/python311Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy
 
-FROM python:3.11-buster
+FROM python:3.11-bookworm
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
- The Buster versions of the python images are in the final support phase and the vulnerability updates are more and more delayed. Therefore moving to the bookworm versions.