### PR TITLE
Update package virtualenv for python:3.9 to fix tests.

### DIFF
--- a/core/requirements_common.txt
+++ b/core/requirements_common.txt
@@ -7,6 +7,6 @@ python-dateutil==2.8.2
 requests==2.26.0
 scrapy==2.5.0
 simplejson==3.17.5
-virtualenv==20.8.0
+virtualenv==20.26.3
 twisted==21.7.0
 netifaces==0.11.0


### PR DESCRIPTION
- The python:3.9 runtime uses an older version of the virtualenv module which now causes 'setup.py install is deprecated' messages to be issued when the action loop loads the function code into memory. This causes the action loop to assume the load failed. This causes the tests to fail. Updating the virtualenv module to version 20.26.3 which is not using 'setup.py' install anymore solves this issue.